### PR TITLE
fixed valuesToString() method;

### DIFF
--- a/src/EnumValues.php
+++ b/src/EnumValues.php
@@ -24,7 +24,7 @@ trait EnumValues
      */
     public static function valuesToString(): string
     {
-        return self::values()->join(', ');
+        return self::values()->join(',');
     }
 
     /**


### PR DESCRIPTION
PHP version: ^8.1
Laravel version: 9.2
Package version: 0.3.1

my enum looks:

```
    case SM = "10-13";
    case MD = "14-19";
    case LG = "20-26";
    case XL = "28";
```

When I used `valuesToString()` method in my request file, this method returned values with space as ["10-13, 14-19, 20-26, 28"];

But for `in:` validation, we need values without any spaces.

I've tried to solve this bug. Can you check my commits, if everything is okay, merge it into new updates?



